### PR TITLE
clean up provider state and make it testable using the state monad

### DIFF
--- a/manners.cabal
+++ b/manners.cabal
@@ -34,6 +34,8 @@ library
                      , vector
                      , wreq
                      , lens
+                     , stm >=2.4
+                     , mtl >=2.2
   default-language:    Haskell2010
 
 executable manners

--- a/src/Pact.hs
+++ b/src/Pact.hs
@@ -27,6 +27,7 @@ import qualified Data.Aeson.Types as AT
 import Control.Monad (liftM)
 import qualified Network.HTTP.Types.Header as HTH
 import qualified Data.CaseInsensitive as CI
+import Data.Monoid (All(..))
 
 hasNullValue :: AT.Pair -> Bool
 hasNullValue (_, Null) = True
@@ -140,7 +141,7 @@ instance ToJSON ContractDescription where
 type Diff = Bool
 
 diffRequests :: Request -> Request -> Diff
-diffRequests expected actual = foldl1 (&&)
+diffRequests expected actual = getAll $ foldMap All
  [ verifyMethod (requestMethod expected) (requestMethod actual)
  , verifyPath (requestPath expected) (requestPath actual)
  , verifyQuery (requestQuery expected) (requestQuery actual)


### PR DESCRIPTION
This uses the state monad for all interactions with the provider state, and executes them by translating into the STM monad.

Things like `recordRequest` could also now be tested easily because they run inside the pure state monad instead of IO.

Also fixes up a small race condition involving `Provider.addInteractionMatch` and `Provider.addMismatchedRequest`.
