### PR TITLE
introduce Headers newtype

### DIFF
--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -7,7 +7,6 @@ module Runner
 import qualified System.Exit as S
 import qualified Data.CaseInsensitive as CI
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.HashMap.Strict as HM
 import qualified Data.Aeson as A
 import qualified Pact as P
 import qualified Control.Monad as C
@@ -60,7 +59,7 @@ performRequest :: BaseUrl -> P.Request -> IO (P.Response)
 performRequest baseUrl req = performMethod method url opts body
   where
     method = CI.foldedCase . CI.mk $ P.requestMethod req
-    headers = P.convertHeadersFromJson $ M.fromMaybe (HM.empty) (P.requestHeaders req)
+    headers = P.convertHeadersFromJson $ P.requestHeaders req
     url = baseUrl ++ (P.requestPath req) ++ (M.fromMaybe "" ((P.requestQuery req) >>= (\x -> return ("?" ++ x))))
     opts = (W.defaults & W.checkStatus .~ (Just (\_ _ _-> Nothing)) & W.headers .~ headers)
     body = (M.fromMaybe "" ((P.requestBody req) >>= (\x -> return $ A.encode x)))
@@ -75,14 +74,14 @@ performMethod "options" url options _ = serialiseResponseEmptyBody <$> W.options
 performMethod _ _ _ _ = error "method not supported"
 
 serialiseResponse :: W.Response BL.ByteString -> P.Response
-serialiseResponse wRes = P.Response (Just actualStatus) (Just actualHeaders) (A.decode actualBody)
+serialiseResponse wRes = P.Response (Just actualStatus) actualHeaders (A.decode actualBody)
   where
     actualStatus = (wRes ^. W.responseStatus . W.statusCode)
     actualHeaders = P.convertHeadersToJson (wRes ^. W.responseHeaders)
     actualBody = (wRes ^. W.responseBody)
 
 serialiseResponseEmptyBody :: W.Response () -> P.Response
-serialiseResponseEmptyBody wRes = P.Response (Just actualStatus) (Just actualHeaders) Nothing
+serialiseResponseEmptyBody wRes = P.Response (Just actualStatus) actualHeaders Nothing
    where
      actualStatus = (wRes ^. W.responseStatus . W.statusCode)
      actualHeaders = P.convertHeadersToJson (wRes ^. W.responseHeaders)

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -98,7 +98,7 @@ providerService fakeProviderState request respond =
       let inMethod = C.unpack $ W.requestMethod request
       let inPath = filter (/='?') $ C.unpack $ W.rawPathInfo request
       let inQuery = Just $ filter (/='?') $ C.unpack $ W.rawQueryString request
-      let inHeaders = Just $ Pact.convertHeadersToJson $ W.requestHeaders request
+      let inHeaders = Pact.convertHeadersToJson $ W.requestHeaders request
       let inBody = decode encodedBody
       let inputRequest = Pact.Request inMethod inPath inQuery inHeaders inBody
 
@@ -115,9 +115,7 @@ providerService fakeProviderState request respond =
                                   resStatus         = toEnum $ case Pact.responseStatus response of
                                                         (Just statusCode) -> statusCode
                                                         Nothing           -> 200
-                                  resHeaders        = case Pact.responseHeaders response of
-                                                        (Just headers) -> Pact.convertHeadersFromJson headers
-                                                        Nothing        -> []
+                                  resHeaders        = Pact.convertHeadersFromJson $ Pact.responseHeaders response
                                   resBody           = case Pact.responseBody response of
                                                         (Just body)    -> encode body
                                                         Nothing        -> ""

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -38,8 +38,8 @@ main = hspec $ around_ withFakeProvider $ do
       let b1 = encode $ Pact.Interaction
                           "a sample interaction"
                           (Just "stateless")
-                          (Pact.Request "get" "/sample" Nothing Nothing Nothing)
-                          (Pact.Response (Just 201) Nothing Nothing)
+                          (Pact.Request "get" "/sample" Nothing mempty Nothing)
+                          (Pact.Response (Just 201) mempty Nothing)
       r1 <- postWith adminOpts "http://localhost:2345/interactions" b1
       (r1 ^. responseStatus . statusCode) `shouldBe` 200
 
@@ -72,8 +72,8 @@ main = hspec $ around_ withFakeProvider $ do
                          [ Pact.Interaction
                            "another interaction"
                            (Just "some_state")
-                           (Pact.Request "GET" "/sample/call" Nothing Nothing Nothing)
-                           (Pact.Response (Just 400) (Just $ HM.fromList [("x-header", "here"), ("content-type", "application/json")]) (Just "bodycontent"))
+                           (Pact.Request "GET" "/sample/call" Nothing mempty Nothing)
+                           (Pact.Response (Just 400) (Pact.Headers [("x-header", "here"), ("content-type", "application/json")]) (Just "bodycontent"))
                          ]
       r8 <- putWith adminOpts "http://localhost:2345/interactions" b8
       (r8 ^. responseStatus . statusCode) `shouldBe` 200
@@ -110,10 +110,10 @@ main = hspec $ around_ withFakeProvider $ do
                          [ Pact.Interaction
                            "a request for hello"
                            Nothing
-                           (Pact.Request "get" "/sayHello" Nothing Nothing Nothing)
+                           (Pact.Request "get" "/sayHello" Nothing mempty Nothing)
                            (Pact.Response
                              (Just 200)
-                             (Just $ HM.fromList [("Content-Type", "application/json")])
+                             (Pact.Headers [("Content-Type", "application/json")])
                              (Just $ Object $ HM.fromList [("reply", String "Hello")]))
                          ]
       r1 <- putWith adminOpts "http://localhost:2345/interactions" b1


### PR DESCRIPTION
For better enscapsulation and strictness, this encodes the pact headers as an association list of strings inside a newtype.
