### PR TITLE
introduce Query newtype

### DIFF
--- a/src/Runner.hs
+++ b/src/Runner.hs
@@ -55,16 +55,16 @@ runContract path baseUrl = do
       print actualResponse
       S.exitFailure
 
-performRequest :: BaseUrl -> P.Request -> IO (P.Response)
+performRequest :: BaseUrl -> P.Request -> IO P.Response
 performRequest baseUrl req = performMethod method url opts body
   where
     method = CI.foldedCase . CI.mk $ P.requestMethod req
     headers = P.convertHeadersFromJson $ P.requestHeaders req
-    url = baseUrl ++ (P.requestPath req) ++ (M.fromMaybe "" ((P.requestQuery req) >>= (\x -> return ("?" ++ x))))
+    url = baseUrl ++ P.requestPath req ++ P.queryString True (P.requestQuery req)
     opts = (W.defaults & W.checkStatus .~ (Just (\_ _ _-> Nothing)) & W.headers .~ headers)
     body = (M.fromMaybe "" ((P.requestBody req) >>= (\x -> return $ A.encode x)))
 
-performMethod :: String -> String -> W.Options -> BL.ByteString -> IO (P.Response)
+performMethod :: String -> String -> W.Options -> BL.ByteString -> IO P.Response
 performMethod "get" url options _ = serialiseResponse <$> W.getWith options url
 performMethod "post" url options body = serialiseResponse <$> W.postWith options url body
 performMethod "put" url options body = serialiseResponse <$> W.putWith options url body

--- a/src/Service.hs
+++ b/src/Service.hs
@@ -95,7 +95,7 @@ providerService fakeProviderState request respond =
       encodedBody <- W.strictRequestBody request
       let inMethod = C.unpack $ W.requestMethod request
       let inPath = filter (/='?') $ C.unpack $ W.rawPathInfo request
-      let inQuery = Just $ filter (/='?') $ C.unpack $ W.rawQueryString request
+      let inQuery = Pact.Query $ H.parseSimpleQuery $ W.rawQueryString request
       let inHeaders = Pact.convertHeadersToJson $ W.requestHeaders request
       let inBody = decode encodedBody
       let inputRequest = Pact.Request inMethod inPath inQuery inHeaders inBody

--- a/test/ServiceSpec.hs
+++ b/test/ServiceSpec.hs
@@ -38,7 +38,7 @@ main = hspec $ around_ withFakeProvider $ do
       let b1 = encode $ Pact.Interaction
                           "a sample interaction"
                           (Just "stateless")
-                          (Pact.Request "get" "/sample" Nothing mempty Nothing)
+                          (Pact.Request "get" "/sample" mempty mempty Nothing)
                           (Pact.Response (Just 201) mempty Nothing)
       r1 <- postWith adminOpts "http://localhost:2345/interactions" b1
       (r1 ^. responseStatus . statusCode) `shouldBe` 200
@@ -72,7 +72,7 @@ main = hspec $ around_ withFakeProvider $ do
                          [ Pact.Interaction
                            "another interaction"
                            (Just "some_state")
-                           (Pact.Request "GET" "/sample/call" Nothing mempty Nothing)
+                           (Pact.Request "GET" "/sample/call" mempty mempty Nothing)
                            (Pact.Response (Just 400) (Pact.Headers [("x-header", "here"), ("content-type", "application/json")]) (Just "bodycontent"))
                          ]
       r8 <- putWith adminOpts "http://localhost:2345/interactions" b8
@@ -110,7 +110,7 @@ main = hspec $ around_ withFakeProvider $ do
                          [ Pact.Interaction
                            "a request for hello"
                            Nothing
-                           (Pact.Request "get" "/sayHello" Nothing mempty Nothing)
+                           (Pact.Request "get" "/sayHello" mempty mempty Nothing)
                            (Pact.Response
                              (Just 200)
                              (Pact.Headers [("Content-Type", "application/json")])


### PR DESCRIPTION
In preparation to clean up the query normalisation logic, this introduces a `Query` newtype, and converts all partial functions (the ones with `error`) into total functions.
