### PR TITLE
fix(client/js): introduce timeout for talking to manners server

### DIFF
--- a/clients/js/manners/index.js
+++ b/clients/js/manners/index.js
@@ -58,7 +58,10 @@ InteractionGroup.prototype.add = function (interaction) {
 
 InteractionGroup.prototype.setup = function (readyFn) {
   var cfg = this._cfg;
-  var axiosCfg = { headers: { 'X-Pact-Mock-Service': 'True' } };
+  var axiosCfg = {
+    timeout: 500,
+    headers: { 'X-Pact-Mock-Service': 'True' }
+  };
   var rethrow = function (fn) {
     return function (err) {
       if (err instanceof ProviderError) { throw err; }


### PR DESCRIPTION
Introducing a timeout for talking to the manners server
will help diagnosing an issue where the setup promise
is never resolved or rejected, and therefore the pact tests
time out, with no clear indication of what went wrong.

If any of the calls to the manners server are the issue,
this should make it visible by rejecting the promise and
providing a proper stack trace to the relevant line.
