### PR TITLE
provide reason for error 'could not write contract'

### DIFF
--- a/clients/js/manners/index.js
+++ b/clients/js/manners/index.js
@@ -111,7 +111,7 @@ InteractionGroup.prototype.setup = function (readyFn) {
       return axios.post(cfg.baseUrl + '/pact', contract, axiosCfg);
     })
     .catch(rethrow(function (err) {
-      throw new ProviderError('Could not write contract');
+      throw new ProviderError('Could not write contract:\n' + err);
     }));
 };
 


### PR DESCRIPTION
Tests in Bamboo failing with the error 'Could not write contract'.

This change adds the original error to the ProviderError message, to help diagnose the problem.
