### PR TITLE
Update Runner.hs to use IP instead of hostname

### DIFF
--- a/cli/src/Runner.hs
+++ b/cli/src/Runner.hs
@@ -57,12 +57,12 @@ runContract path baseUrl = do
     teardownState $ P.interactionState i
 
 setupState :: Maybe String -> IO ()
-setupState (Just state) = W.post "http://localhost:2345/post" (getPayload "setup" state) >> pure ()
-setupState Nothing      = W.post "http://localhost:2345/post" (getPayload "setup" "__MANNERS_DEFAULT_STATE__") >> pure ()
+setupState (Just state) = W.post "http://127.0.0.1:2345/post" (getPayload "setup" state) >> pure ()
+setupState Nothing      = W.post "http://127.0.0.1:2345/post" (getPayload "setup" "__MANNERS_DEFAULT_STATE__") >> pure ()
 
 teardownState :: Maybe String -> IO ()
-teardownState (Just state) = W.post "http://localhost:2345/post" (getPayload "teardown" state) >> pure ()
-teardownState Nothing      = W.post "http://localhost:2345/post" (getPayload "teardown" "__MANNERS_DEFAULT_STATE__") >> pure ()
+teardownState (Just state) = W.post "http://127.0.0.1:2345/post" (getPayload "teardown" state) >> pure ()
+teardownState Nothing      = W.post "http://127.0.0.1:2345/post" (getPayload "teardown" "__MANNERS_DEFAULT_STATE__") >> pure ()
 
 getPayload :: T.Text -> String -> BL.ByteString
 getPayload hook state = A.encode $ A.object [(A..=) "type" (A.String hook), (A..=) "state" (A.String (T.pack state))]


### PR DESCRIPTION
Hi @damienklinnert 

Using the hostname `localhost` requires resolving it to an IP address (as you already know). Unfortunately this causes a runtime error with the `getAddrInfo` function on specific environments. Here is the full error:

```
manners-0.5.0.0-x86_64-linux: FailedConnectionException2 "localhost" 2345 False getAddrInfo: does not exist (System error)
FAILURE Error: Failed to run fake-consumer
    at ChildProcess.<anonymous> (...)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:192:7)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:215:12)
```

Thanks to @srijs who found the root cause, and helped with this fix. Recompiling with `stack build` with static flags somehow seems to fix this issue. But using the hostname is not really necessary for this use case. It would be great if you could merge and release another version shortly.

Thanks!
