### PR TITLE
Fix ServiceSpec.hs to use IP adds for interactions

### DIFF
--- a/cli/test/ServiceSpec.hs
+++ b/cli/test/ServiceSpec.hs
@@ -40,31 +40,31 @@ main = hspec $ around_ withFakeProvider $ do
                           (Just "stateless")
                           (Pact.Request "get" "/sample" mempty mempty Nothing)
                           (Pact.Response (Just 201) mempty Nothing)
-      r1 <- postWith adminOpts "http://localhost:2345/interactions" b1
+      r1 <- postWith adminOpts "http://127.0.0.1:2345/interactions" b1
       (r1 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- do the interaction
-      r2 <- get "http://localhost:2345/sample"
+      r2 <- get "http://127.0.0.1:2345/sample"
       (r2 ^. responseStatus . statusCode) `shouldBe` 201
 
       -- ensure that verify works
-      r3 <- getWith adminOpts "http://localhost:2345/interactions/verification"
+      r3 <- getWith adminOpts "http://127.0.0.1:2345/interactions/verification"
       (r3 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- do unspecified request
-      r4 <- getWith allowServerErrorOpts "http://localhost:2345/no-sample"
+      r4 <- getWith allowServerErrorOpts "http://127.0.0.1:2345/no-sample"
       (r4 ^. responseStatus . statusCode) `shouldBe` 500
 
       -- ensure that verify fails
-      r5 <- getWith adminOpts "http://localhost:2345/interactions/verification"
+      r5 <- getWith adminOpts "http://127.0.0.1:2345/interactions/verification"
       (r5 ^. responseStatus . statusCode) `shouldBe` 500
 
       -- delete all interactions
-      r6 <- deleteWith adminOpts "http://localhost:2345/interactions"
+      r6 <- deleteWith adminOpts "http://127.0.0.1:2345/interactions"
       (r6 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- verify should work again now
-      r7 <- getWith adminOpts "http://localhost:2345/interactions/verification"
+      r7 <- getWith adminOpts "http://127.0.0.1:2345/interactions/verification"
       (r7 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- set interations to another one
@@ -75,27 +75,27 @@ main = hspec $ around_ withFakeProvider $ do
                            (Pact.Request "GET" "/sample/call" mempty mempty Nothing)
                            (Pact.Response (Just 400) (Pact.Headers [("x-header", "here"), ("content-type", "application/json")]) (Just "bodycontent"))
                          ]
-      r8 <- putWith adminOpts "http://localhost:2345/interactions" b8
+      r8 <- putWith adminOpts "http://127.0.0.1:2345/interactions" b8
       (r8 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- verification should fail now
-      r9 <- getWith adminOpts "http://localhost:2345/interactions/verification"
+      r9 <- getWith adminOpts "http://127.0.0.1:2345/interactions/verification"
       (r9 ^. responseStatus . statusCode) `shouldBe` 500
 
       -- do the proper interaction now
-      r10 <- getWith allowServerErrorOpts "http://localhost:2345/sample/call"
+      r10 <- getWith allowServerErrorOpts "http://127.0.0.1:2345/sample/call"
       (r10 ^. responseStatus . statusCode) `shouldBe` 400
       (r10 ^. responseHeader "x-header") `shouldBe` "here"
       (r10 ^. responseHeader "content-type") `shouldBe` "application/json"
       (r10 ^. responseBody) `shouldBe` "\"bodycontent\""
 
       -- now verify should work again
-      r11 <- getWith adminOpts "http://localhost:2345/interactions/verification"
+      r11 <- getWith adminOpts "http://127.0.0.1:2345/interactions/verification"
       (r11 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- persist contract
       let b12 = encode $ Pact.ContractDescription (Pact.ServiceDescription "a") (Pact.ServiceDescription "b") []
-      r12 <- postWith adminOpts "http://localhost:2345/pact" b12
+      r12 <- postWith adminOpts "http://127.0.0.1:2345/pact" b12
       (r12 ^. responseStatus . statusCode) `shouldBe` 200
 
       -- check that the contract was written properly
@@ -116,10 +116,10 @@ main = hspec $ around_ withFakeProvider $ do
                              (Pact.Headers [("Content-Type", "application/json")])
                              (Just $ Object $ HM.fromList [("reply", String "Hello")]))
                          ]
-      r1 <- putWith adminOpts "http://localhost:2345/interactions" b1
+      r1 <- putWith adminOpts "http://127.0.0.1:2345/interactions" b1
       (r1 ^. responseStatus . statusCode) `shouldBe` 200
 
-      r2 <- get "http://localhost:2345/sayHello"
+      r2 <- get "http://127.0.0.1:2345/sayHello"
       (r2 ^. responseStatus . statusCode) `shouldBe` 200
       (decode (r2 ^. responseBody)) `shouldBe` (Just $ Object $ HM.fromList [("reply", String "Hello")])
 
@@ -127,7 +127,7 @@ main = hspec $ around_ withFakeProvider $ do
                            (Pact.ServiceDescription "Hello Consumer")
                            (Pact.ServiceDescription "Hello Provider")
                            []
-      r3 <- postWith adminOpts "http://localhost:2345/pact" b3
+      r3 <- postWith adminOpts "http://127.0.0.1:2345/pact" b3
       (r3 ^. responseStatus . statusCode) `shouldBe` 200
 
       let b4 = BLC.pack [str|{ "interactions": [{
@@ -145,18 +145,18 @@ main = hspec $ around_ withFakeProvider $ do
                             |  }
                             |}]}
                             |]
-      r4 <- putWith adminOpts "http://localhost:2345/interactions" b4
+      r4 <- putWith adminOpts "http://127.0.0.1:2345/interactions" b4
       (r4 ^. responseStatus . statusCode) `shouldBe` 200
 
       let r5opts = (allowServerErrorOpts &
                       param "age" .~ ["30"] &
                       param "children" .~ ["Mary Jane", "James"] &
                       header "Accept" .~ ["application/json"])
-      r5 <- getWith r5opts "http://localhost:2345/friends"
+      r5 <- getWith r5opts "http://127.0.0.1:2345/friends"
       (r5 ^. responseStatus . statusCode) `shouldBe` 200
       ((decode $ r5 ^. responseBody) :: Maybe Object) `shouldBe` (decode $ BLC.pack [str|{ "friends": [{"name": "Sue"}] }|])
 
-      r6 <- postWith adminOpts "http://localhost:2345/pact" b3
+      r6 <- postWith adminOpts "http://127.0.0.1:2345/pact" b3
       (r6 ^. responseStatus . statusCode) `shouldBe` 200
 
       let b7 = BLC.pack [str|{ "interactions": [{
@@ -173,14 +173,14 @@ main = hspec $ around_ withFakeProvider $ do
                                   |  }
                                   |}]}
                                   |]
-      r7 <- putWith adminOpts "http://localhost:2345/interactions" b7
+      r7 <- putWith adminOpts "http://127.0.0.1:2345/interactions" b7
       (r7 ^. responseStatus . statusCode) `shouldBe` 200
 
-      r8 <- put "http://localhost:2345/unfriendMe" BL.empty
+      r8 <- put "http://127.0.0.1:2345/unfriendMe" BL.empty
       (r8 ^. responseStatus . statusCode) `shouldBe` 200
       ((decode $ r8 ^. responseBody) :: Maybe Object) `shouldBe` (decode $ BLC.pack [str|{ "reply": "Bye" }|])
 
-      r9 <- postWith adminOpts "http://localhost:2345/pact" b3
+      r9 <- postWith adminOpts "http://127.0.0.1:2345/pact" b3
       (r9 ^. responseStatus . statusCode) `shouldBe` 200
 
       let b10 = BLC.pack [str|{ "interactions": [{
@@ -195,13 +195,13 @@ main = hspec $ around_ withFakeProvider $ do
                                         |  }
                                         |}]}
                                         |]
-      r10 <- putWith adminOpts "http://localhost:2345/interactions" b10
+      r10 <- putWith adminOpts "http://127.0.0.1:2345/interactions" b10
       (r10 ^. responseStatus . statusCode) `shouldBe` 200
 
-      r11 <- putWith allowServerErrorOpts "http://localhost:2345/unfriendMe" BL.empty
+      r11 <- putWith allowServerErrorOpts "http://127.0.0.1:2345/unfriendMe" BL.empty
       (r11 ^. responseStatus . statusCode) `shouldBe` 404
 
-      r12 <- postWith adminOpts "http://localhost:2345/pact" b3
+      r12 <- postWith adminOpts "http://127.0.0.1:2345/pact" b3
       (r12 ^. responseStatus . statusCode) `shouldBe` 200
 
       modelContents <- BL.readFile "test/resources/Hello Consumer-Hello Provider.json"
@@ -225,18 +225,18 @@ main = hspec $ around_ withFakeProvider $ do
                              (Pact.Headers [("Content-Type", "application/json")])
                              (Just $ Object $ HM.fromList [("reply", String "Hello")]))
                          ]
-      r1 <- putWith adminOpts "http://localhost:2345/interactions" r1Body
+      r1 <- putWith adminOpts "http://127.0.0.1:2345/interactions" r1Body
       (r1 ^. responseStatus . statusCode) `shouldBe` 200
 
       let r2Opts = (allowServerErrorOpts &
                       header "x-header" .~ ["here"] &
                       header "content-type" .~ ["application/json"])
 
-      r2 <- getWith r2Opts "http://localhost:2345/sayHello"
+      r2 <- getWith r2Opts "http://127.0.0.1:2345/sayHello"
       (r2 ^. responseStatus . statusCode) `shouldBe` 200
       (decode (r2 ^. responseBody)) `shouldBe` (Just $ Object $ HM.fromList [("reply", String "Hello")])
 
     it "regression test for #30 - fake-provider throws unhandled exception on json decoding error" $ do
       let r1Body = BLC.pack "{ faulty }"
-      r1 <- putWith adminOpts "http://localhost:2345/interactions" r1Body
+      r1 <- putWith adminOpts "http://127.0.0.1:2345/interactions" r1Body
       (r1 ^. responseStatus . statusCode) `shouldBe` 500


### PR DESCRIPTION
Fixes the CI breakage introduced by the changes in https://github.com/mannersio/manners/pull/44

Ran `stack test` to confirm the breakage from https://travis-ci.org/mannersio/manners/jobs/209688225